### PR TITLE
feat(judges): endpoints /casos y /archivos con paginación y modelo de juez enriquecido

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -623,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -654,6 +655,7 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -714,6 +716,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -910,6 +913,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -965,6 +969,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1097,6 +1102,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1453,6 +1459,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2082,6 +2089,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2354,6 +2362,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4084,6 +4093,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -4302,7 +4312,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4399,6 +4410,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -4832,6 +4844,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5057,6 +5070,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/judges/judges.controller.ts
+++ b/src/judges/judges.controller.ts
@@ -16,4 +16,18 @@ export class JudgesController {
     if (!judge) throw new NotFoundException(`Juez con id ${id} no encontrado`);
     return judge;
   }
+
+  @Get(':id/casos')
+  getCasos(@Param('id', ParseIntPipe) id: number) {
+    const judge = this.judgesService.findOne(id);
+    if (!judge) throw new NotFoundException(`Juez con id ${id} no encontrado`);
+    return this.judgesService.getCasosByJudge(id);
+  }
+
+  @Get(':id/archivos')
+  getArchivos(@Param('id', ParseIntPipe) id: number) {
+    const judge = this.judgesService.findOne(id);
+    if (!judge) throw new NotFoundException(`Juez con id ${id} no encontrado`);
+    return this.judgesService.getArchivosByJudge(id);
+  }
 }

--- a/src/judges/judges.controller.ts
+++ b/src/judges/judges.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe, NotFoundException } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { JudgesService } from './judges.service';
 
 @Controller('judges')
@@ -18,10 +18,14 @@ export class JudgesController {
   }
 
   @Get(':id/casos')
-  getCasos(@Param('id', ParseIntPipe) id: number) {
+  getCasos(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ) {
     const judge = this.judgesService.findOne(id);
     if (!judge) throw new NotFoundException(`Juez con id ${id} no encontrado`);
-    return this.judgesService.getCasosByJudge(id);
+    return this.judgesService.getCasosByJudge(id, Number(page), Number(limit));
   }
 
   @Get(':id/archivos')

--- a/src/judges/judges.interface.ts
+++ b/src/judges/judges.interface.ts
@@ -119,6 +119,14 @@ export interface JudgeWithStats extends Judge {
   failureRate: number;
 }
 
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 export type ResultadoCaso = 'fta' | 'nuevo_arresto' | 'revocada' | 'pendiente';
 
 export interface Caso {

--- a/src/judges/judges.interface.ts
+++ b/src/judges/judges.interface.ts
@@ -118,3 +118,23 @@ export interface JudgeWithStats extends Judge {
   totalFailures: number;
   failureRate: number;
 }
+
+export type ResultadoCaso = 'fta' | 'nuevo_arresto' | 'revocada' | 'pendiente';
+
+export interface Caso {
+  id: string;
+  judgeId: number;
+  nroExpediente: string;
+  fechaResolucion: string; // ISO date (YYYY-MM-DD)
+  tipoMedida: string;
+  resultado: ResultadoCaso;
+  observaciones?: string;
+}
+
+export interface ArchivoPublico {
+  id: string;
+  judgeId: number;
+  nombre: string;
+  url: string;
+  fechaCarga: string; // ISO date (YYYY-MM-DD)
+}

--- a/src/judges/judges.service.ts
+++ b/src/judges/judges.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ArchivoPublico, Caso, Judge, JudgeWithStats } from './judges.interface';
+import { ArchivoPublico, Caso, Judge, JudgeWithStats, PaginatedResult } from './judges.interface';
 
 /*
  * ─────────────────────────────────────────────────────────────────────────────
@@ -1282,8 +1282,13 @@ export class JudgesService {
     return MOCK_JUDGES;
   }
 
-  getCasosByJudge(judgeId: number): Caso[] {
-    return MOCK_CASOS.filter((c) => c.judgeId === judgeId);
+  getCasosByJudge(judgeId: number, page = 1, limit = 10): PaginatedResult<Caso> {
+    const all = MOCK_CASOS.filter((c) => c.judgeId === judgeId);
+    const total = all.length;
+    const totalPages = Math.ceil(total / limit);
+    const safePage = Math.min(Math.max(1, page), totalPages || 1);
+    const data = all.slice((safePage - 1) * limit, safePage * limit);
+    return { data, total, page: safePage, limit, totalPages };
   }
 
   getArchivosByJudge(judgeId: number): ArchivoPublico[] {

--- a/src/judges/judges.service.ts
+++ b/src/judges/judges.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Judge, JudgeWithStats } from './judges.interface';
+import { ArchivoPublico, Caso, Judge, JudgeWithStats } from './judges.interface';
 
 /*
  * ─────────────────────────────────────────────────────────────────────────────
@@ -19,7 +19,6 @@ import { Judge, JudgeWithStats } from './judges.interface';
  */
 
 const MOCK_JUDGES: Judge[] = [
-
   // ══════════════════════════════════════════════════════════════════════════
   // JUEZ 1 — CABA · Primera instancia · Nacional · Ordinaria
   // ══════════════════════════════════════════════════════════════════════════
@@ -48,8 +47,7 @@ const MOCK_JUDGES: Judge[] = [
       lastUpdated: 'diciembre 2024',
     },
     appointmentDate: '15 de marzo de 2018',
-    appointmentBody:
-      'Consejo de la Magistratura de la Nación — Decreto PEN N° 512/2018',
+    appointmentBody: 'Consejo de la Magistratura de la Nación — Decreto PEN N° 512/2018',
     yearsOnBench: 7,
     totalReleases: 491,
     ftaCount: 67,
@@ -139,7 +137,8 @@ const MOCK_JUDGES: Judge[] = [
         crimeArticle: 'Art. 84 bis CP (Ley 27.347)',
         decisionType: 'Exención de prisión bajo caución real',
         decisionDate: '2024-02-19',
-        legalBasis: 'Art. 316 CPPN — delito culposo sin antecedentes; domicilio y trabajo acreditados',
+        legalBasis:
+          'Art. 316 CPPN — delito culposo sin antecedentes; domicilio y trabajo acreditados',
         outcome: 'ongoing',
         outcomeDetail: 'Investigación en trámite. Pericia accidentológica pendiente.',
       },
@@ -150,11 +149,11 @@ const MOCK_JUDGES: Judge[] = [
         crimeArticle: 'Art. 119, 3° párr. CP',
         decisionType: 'Excarcelación bajo caución real',
         decisionDate: '2021-07-30',
-        legalBasis: 'Art. 317 CPPN — tiempo de detención preventiva excede el mínimo de la escala penal',
+        legalBasis:
+          'Art. 317 CPPN — tiempo de detención preventiva excede el mínimo de la escala penal',
         outcome: 'revoked',
         outcomeDate: '2021-10-14',
-        outcomeDetail:
-          'Libertad revocada al constatarse contacto no autorizado con la víctima.',
+        outcomeDetail: 'Libertad revocada al constatarse contacto no autorizado con la víctima.',
       },
       {
         expediente: '52789/2022',
@@ -191,7 +190,8 @@ const MOCK_JUDGES: Judge[] = [
       {
         label: 'Consejo de la Magistratura — Legajo del magistrado',
         url: 'https://www.magistratura.gov.ar/magistrados/legajo',
-        description: 'Legajo público: concurso de designación, antecedentes disciplinarios y DJ patrimonial.',
+        description:
+          'Legajo público: concurso de designación, antecedentes disciplinarios y DJ patrimonial.',
       },
       {
         label: 'CSJN — Acordadas de remuneraciones',
@@ -201,7 +201,8 @@ const MOCK_JUDGES: Judge[] = [
       {
         label: 'Ministerio Público Fiscal — Resoluciones',
         url: 'https://www.mpf.gov.ar/resoluciones',
-        description: 'Resoluciones del MPF. Complementa el seguimiento con la posición del acusador.',
+        description:
+          'Resoluciones del MPF. Complementa el seguimiento con la posición del acusador.',
       },
       {
         label: 'Oficina Anticorrupción — Declaraciones Juradas',
@@ -235,8 +236,7 @@ const MOCK_JUDGES: Judge[] = [
       scope: 'Provincial',
       competence: 'Ordinaria',
     },
-    workAddress:
-      'Calle 13 N° 820, Piso 4, Sala II — La Plata, Buenos Aires, CP B1900TLH',
+    workAddress: 'Calle 13 N° 820, Piso 4, Sala II — La Plata, Buenos Aires, CP B1900TLH',
     workHours: 'Lunes a viernes de 08:00 a 14:00 hs. (Acordada SCBA N° 3845/2019)',
     salary: {
       grossMonthlyARS: 12_400_000,
@@ -275,7 +275,8 @@ const MOCK_JUDGES: Judge[] = [
       },
       {
         degree: 'Diploma en Derechos Humanos y Proceso Penal',
-        institution: 'ILANUD — Instituto Latinoamericano de Naciones Unidas para la Prevención del Delito',
+        institution:
+          'ILANUD — Instituto Latinoamericano de Naciones Unidas para la Prevención del Delito',
         year: 2007,
       },
     ],
@@ -328,8 +329,7 @@ const MOCK_JUDGES: Judge[] = [
           'Declaró la inconstitucionalidad de la detención preventiva automática ' +
           'en causa de reincidencia simple, por exceder el estándar de proporcionalidad.',
         article: 'Art. 170 CPPPBA · Art. 18 CN · Doctrina CIDH',
-        outcome:
-          'Resolución recurrida por la Fiscalía. La SCBA confirmó el criterio de la Cámara.',
+        outcome: 'Resolución recurrida por la Fiscalía. La SCBA confirmó el criterio de la Cámara.',
       },
     ],
 
@@ -501,8 +501,7 @@ const MOCK_JUDGES: Judge[] = [
       scope: 'Federal',
       competence: 'Federal',
     },
-    workAddress:
-      'Av. General Paz 102, Piso 5, Of. 512 — Córdoba Capital, CP X5000IYN',
+    workAddress: 'Av. General Paz 102, Piso 5, Of. 512 — Córdoba Capital, CP X5000IYN',
     workHours: 'Lunes a viernes de 07:30 a 13:30 hs. (Acordada CSJN N° 4/2007)',
     salary: {
       grossMonthlyARS: 8_650_000,
@@ -511,8 +510,7 @@ const MOCK_JUDGES: Judge[] = [
       lastUpdated: 'diciembre 2024',
     },
     appointmentDate: '22 de septiembre de 2020',
-    appointmentBody:
-      'Consejo de la Magistratura de la Nación — Decreto PEN N° 884/2020',
+    appointmentBody: 'Consejo de la Magistratura de la Nación — Decreto PEN N° 884/2020',
     yearsOnBench: 5,
     totalReleases: 213,
     ftaCount: 19,
@@ -658,7 +656,8 @@ const MOCK_JUDGES: Judge[] = [
         crimeArticle: 'Art. 865 inc. b) Código Aduanero (Ley 22.415)',
         decisionType: 'Excarcelación bajo caución personal juratoria',
         decisionDate: '2022-03-25',
-        legalBasis: 'Art. 210 CPPF — monto de la pena en expectativa no excede el umbral de cautelar',
+        legalBasis:
+          'Art. 210 CPPF — monto de la pena en expectativa no excede el umbral de cautelar',
         outcome: 'ongoing',
         outcomeDetail: 'Causa en etapa de juicio. Debate oral fijado para 2025.',
       },
@@ -720,7 +719,8 @@ const MOCK_JUDGES: Judge[] = [
         crimeArticle: 'Art. 2 Ley 24.769 (Régimen Penal Tributario)',
         decisionType: 'Exención de prisión bajo caución real',
         decisionDate: '2019-09-30',
-        legalBasis: 'Art. 316 CPPN (vigente en ese momento) — monto de evasión acreditado; arraigo suficiente',
+        legalBasis:
+          'Art. 316 CPPN (vigente en ese momento) — monto de evasión acreditado; arraigo suficiente',
         outcome: 'fta',
         outcomeDate: '2020-04-17',
         outcomeDetail:
@@ -733,7 +733,8 @@ const MOCK_JUDGES: Judge[] = [
       {
         label: 'PJN — Expedientes Federales de Córdoba',
         url: 'https://www.pjn.gov.ar/judiciales/expedientes',
-        description: 'Sistema de gestión judicial. Consulta de causas federales por número de expediente.',
+        description:
+          'Sistema de gestión judicial. Consulta de causas federales por número de expediente.',
       },
       {
         label: 'Consejo de la Magistratura — Legajo del magistrado',
@@ -748,7 +749,8 @@ const MOCK_JUDGES: Judge[] = [
       {
         label: 'UIF — Unidad de Información Financiera',
         url: 'https://www.argentina.gob.ar/uif',
-        description: 'Reportes de operaciones sospechosas y resoluciones en causas de lavado de activos.',
+        description:
+          'Reportes de operaciones sospechosas y resoluciones en causas de lavado de activos.',
       },
       {
         label: 'AFIP — PROCELAC (Procuraduría de Criminalidad Económica)',
@@ -758,9 +760,504 @@ const MOCK_JUDGES: Judge[] = [
       {
         label: 'SAIJ — Legislación y jurisprudencia federal',
         url: 'https://www.saij.gob.ar',
-        description: 'Sistema Argentino de Información Jurídica. Base normativa y jurisprudencial oficial.',
+        description:
+          'Sistema Argentino de Información Jurídica. Base normativa y jurisprudencial oficial.',
       },
     ],
+  },
+];
+
+const MOCK_CASOS: Caso[] = [
+  // ── Juez 1: García Morales (CABA) ────────────────────────────────────────
+  {
+    id: 'c-101',
+    judgeId: 1,
+    nroExpediente: '98432/2023',
+    fechaResolucion: '2023-08-14',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Reaprehendido el 02/10/2023 por robo agravado en San Telmo.',
+  },
+  {
+    id: 'c-102',
+    judgeId: 1,
+    nroExpediente: '12987/2023',
+    fechaResolucion: '2023-11-03',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'No se presentó a la audiencia del 15/12/2023.',
+  },
+  {
+    id: 'c-103',
+    judgeId: 1,
+    nroExpediente: '45621/2024',
+    fechaResolucion: '2024-02-20',
+    tipoMedida: 'Prisión preventiva atenuada',
+    resultado: 'revocada',
+    observaciones: 'La Cámara revocó por incumplimiento de reglas de conducta.',
+  },
+  {
+    id: 'c-104',
+    judgeId: 1,
+    nroExpediente: '67890/2024',
+    fechaResolucion: '2024-05-10',
+    tipoMedida: 'Libertad bajo caución real',
+    resultado: 'pendiente',
+  },
+  // ── Jueza 2: Vidal Suárez (CABA) ─────────────────────────────────────────
+  {
+    id: 'c-201',
+    judgeId: 2,
+    nroExpediente: '33210/2023',
+    fechaResolucion: '2023-07-22',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'Paradero desconocido desde agosto de 2023.',
+  },
+  {
+    id: 'c-202',
+    judgeId: 2,
+    nroExpediente: '54871/2023',
+    fechaResolucion: '2023-12-01',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Detenido nuevamente el 18/01/2024 por tentativa de homicidio.',
+  },
+  {
+    id: 'c-203',
+    judgeId: 2,
+    nroExpediente: '11023/2024',
+    fechaResolucion: '2024-03-15',
+    tipoMedida: 'Arresto domiciliario',
+    resultado: 'pendiente',
+  },
+  // ── Juez 3: Espinoza Leal (CABA) ─────────────────────────────────────────
+  {
+    id: 'c-301',
+    judgeId: 3,
+    nroExpediente: '78123/2022',
+    fechaResolucion: '2022-09-05',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Detenido por segundo hecho el 22/10/2022 en Palermo.',
+  },
+  {
+    id: 'c-302',
+    judgeId: 3,
+    nroExpediente: '90045/2022',
+    fechaResolucion: '2022-11-18',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+  },
+  {
+    id: 'c-303',
+    judgeId: 3,
+    nroExpediente: '14532/2023',
+    fechaResolucion: '2023-04-07',
+    tipoMedida: 'Libertad bajo caución juratoria',
+    resultado: 'revocada',
+    observaciones: 'Revocada por reiteración delictiva comprobada.',
+  },
+  {
+    id: 'c-304',
+    judgeId: 3,
+    nroExpediente: '62791/2023',
+    fechaResolucion: '2023-09-30',
+    tipoMedida: 'Prisión preventiva atenuada',
+    resultado: 'nuevo_arresto',
+  },
+  {
+    id: 'c-305',
+    judgeId: 3,
+    nroExpediente: '29841/2024',
+    fechaResolucion: '2024-01-22',
+    tipoMedida: 'Excarcelación',
+    resultado: 'pendiente',
+  },
+  // ── Jueza 4: Castro Ruiz (CABA) ───────────────────────────────────────────
+  {
+    id: 'c-401',
+    judgeId: 4,
+    nroExpediente: '43219/2023',
+    fechaResolucion: '2023-06-14',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'Incomparecencia a audiencia de control del 20/07/2023.',
+  },
+  {
+    id: 'c-402',
+    judgeId: 4,
+    nroExpediente: '87654/2023',
+    fechaResolucion: '2023-10-28',
+    tipoMedida: 'Excarcelación',
+    resultado: 'pendiente',
+  },
+  {
+    id: 'c-403',
+    judgeId: 4,
+    nroExpediente: '55320/2024',
+    fechaResolucion: '2024-04-03',
+    tipoMedida: 'Arresto domiciliario',
+    resultado: 'revocada',
+    observaciones: 'Quebrantó condiciones del arresto domiciliario.',
+  },
+  // ── Juez 5: Torres Ibáñez (BA - La Matanza) ───────────────────────────────
+  {
+    id: 'c-501',
+    judgeId: 5,
+    nroExpediente: '31456/2022',
+    fechaResolucion: '2022-10-11',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Nuevo hecho delictivo el 05/11/2022.',
+  },
+  {
+    id: 'c-502',
+    judgeId: 5,
+    nroExpediente: '79023/2023',
+    fechaResolucion: '2023-03-20',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+  },
+  {
+    id: 'c-503',
+    judgeId: 5,
+    nroExpediente: '15678/2023',
+    fechaResolucion: '2023-08-09',
+    tipoMedida: 'Libertad bajo caución real',
+    resultado: 'revocada',
+  },
+  {
+    id: 'c-504',
+    judgeId: 5,
+    nroExpediente: '48921/2024',
+    fechaResolucion: '2024-02-14',
+    tipoMedida: 'Prisión preventiva atenuada',
+    resultado: 'pendiente',
+  },
+  // ── Jueza 6: González Ruiz (BA - La Matanza) ──────────────────────────────
+  {
+    id: 'c-601',
+    judgeId: 6,
+    nroExpediente: '22134/2022',
+    fechaResolucion: '2022-08-30',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Arrestado por robo calificado el 14/09/2022.',
+  },
+  {
+    id: 'c-602',
+    judgeId: 6,
+    nroExpediente: '66543/2022',
+    fechaResolucion: '2022-12-15',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'Sin noticias del imputado desde enero 2023.',
+  },
+  {
+    id: 'c-603',
+    judgeId: 6,
+    nroExpediente: '10982/2023',
+    fechaResolucion: '2023-05-04',
+    tipoMedida: 'Libertad bajo caución juratoria',
+    resultado: 'revocada',
+  },
+  {
+    id: 'c-604',
+    judgeId: 6,
+    nroExpediente: '39871/2024',
+    fechaResolucion: '2024-03-28',
+    tipoMedida: 'Arresto domiciliario',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Quebrantó el arresto y cometió nuevo delito.',
+  },
+  // ── Jueza 7: Pereyra Blanco (BA - La Plata) ───────────────────────────────
+  {
+    id: 'c-701',
+    judgeId: 7,
+    nroExpediente: '57831/2023',
+    fechaResolucion: '2023-02-17',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'No compareció al control mensual del 17/03/2023.',
+  },
+  {
+    id: 'c-702',
+    judgeId: 7,
+    nroExpediente: '84290/2023',
+    fechaResolucion: '2023-09-22',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+  },
+  {
+    id: 'c-703',
+    judgeId: 7,
+    nroExpediente: '27654/2024',
+    fechaResolucion: '2024-01-08',
+    tipoMedida: 'Prisión preventiva atenuada',
+    resultado: 'pendiente',
+  },
+  // ── Juez 8: Méndez Vega (BA - La Plata) ──────────────────────────────────
+  {
+    id: 'c-801',
+    judgeId: 8,
+    nroExpediente: '19023/2023',
+    fechaResolucion: '2023-04-14',
+    tipoMedida: 'Excarcelación',
+    resultado: 'revocada',
+    observaciones: 'Revocada por la Cámara ante reiteración delictiva.',
+  },
+  {
+    id: 'c-802',
+    judgeId: 8,
+    nroExpediente: '63410/2023',
+    fechaResolucion: '2023-10-30',
+    tipoMedida: 'Libertad bajo caución real',
+    resultado: 'fta',
+  },
+  {
+    id: 'c-803',
+    judgeId: 8,
+    nroExpediente: '41287/2024',
+    fechaResolucion: '2024-04-19',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'pendiente',
+  },
+  // ── Jueza 9: Fernández Ríos (Córdoba) ────────────────────────────────────
+  {
+    id: 'c-901',
+    judgeId: 9,
+    nroExpediente: '72341/2023',
+    fechaResolucion: '2023-05-08',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+  },
+  {
+    id: 'c-902',
+    judgeId: 9,
+    nroExpediente: '35912/2023',
+    fechaResolucion: '2023-11-14',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Detenido por hecho independiente el 09/12/2023.',
+  },
+  {
+    id: 'c-903',
+    judgeId: 9,
+    nroExpediente: '88124/2024',
+    fechaResolucion: '2024-03-07',
+    tipoMedida: 'Prisión preventiva atenuada',
+    resultado: 'pendiente',
+  },
+  // ── Jueza 10: Ramos Prieto (Córdoba) ─────────────────────────────────────
+  {
+    id: 'c-1001',
+    judgeId: 10,
+    nroExpediente: '29087/2023',
+    fechaResolucion: '2023-06-19',
+    tipoMedida: 'Libertad bajo caución juratoria',
+    resultado: 'fta',
+    observaciones: 'Incomparecencia sin justificación.',
+  },
+  {
+    id: 'c-1002',
+    judgeId: 10,
+    nroExpediente: '51340/2023',
+    fechaResolucion: '2023-12-05',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+  },
+  {
+    id: 'c-1003',
+    judgeId: 10,
+    nroExpediente: '17623/2024',
+    fechaResolucion: '2024-02-28',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'pendiente',
+  },
+  // ── Juez 11: Herrera Montoya (Santa Fe - Rosario) ─────────────────────────
+  {
+    id: 'c-1101',
+    judgeId: 11,
+    nroExpediente: '84561/2022',
+    fechaResolucion: '2022-07-22',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+    observaciones: 'Nuevo hecho el 08/08/2022 en zona norte de Rosario.',
+  },
+  {
+    id: 'c-1102',
+    judgeId: 11,
+    nroExpediente: '43219/2022',
+    fechaResolucion: '2022-11-10',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+  },
+  {
+    id: 'c-1103',
+    judgeId: 11,
+    nroExpediente: '19034/2023',
+    fechaResolucion: '2023-04-25',
+    tipoMedida: 'Libertad bajo caución real',
+    resultado: 'revocada',
+    observaciones: 'La Sala revocó la medida por inconducta procesal reiterada.',
+  },
+  {
+    id: 'c-1104',
+    judgeId: 11,
+    nroExpediente: '67821/2023',
+    fechaResolucion: '2023-09-03',
+    tipoMedida: 'Arresto domiciliario',
+    resultado: 'nuevo_arresto',
+  },
+  {
+    id: 'c-1105',
+    judgeId: 11,
+    nroExpediente: '32456/2024',
+    fechaResolucion: '2024-01-15',
+    tipoMedida: 'Excarcelación',
+    resultado: 'pendiente',
+  },
+  // ── Juez 12: Molina Sosa (Santa Fe - Rosario) ─────────────────────────────
+  {
+    id: 'c-1201',
+    judgeId: 12,
+    nroExpediente: '91230/2023',
+    fechaResolucion: '2023-03-11',
+    tipoMedida: 'Libertad cautelar',
+    resultado: 'fta',
+    observaciones: 'Incomparecencia a audiencia del 14/04/2023.',
+  },
+  {
+    id: 'c-1202',
+    judgeId: 12,
+    nroExpediente: '58743/2023',
+    fechaResolucion: '2023-08-29',
+    tipoMedida: 'Excarcelación',
+    resultado: 'nuevo_arresto',
+  },
+  {
+    id: 'c-1203',
+    judgeId: 12,
+    nroExpediente: '24891/2024',
+    fechaResolucion: '2024-04-10',
+    tipoMedida: 'Arresto domiciliario',
+    resultado: 'pendiente',
+  },
+];
+
+const MOCK_ARCHIVOS: ArchivoPublico[] = [
+  {
+    id: 'a-101',
+    judgeId: 1,
+    nombre: 'Resolución excarcelación 98432-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-08-20',
+  },
+  {
+    id: 'a-102',
+    judgeId: 1,
+    nombre: 'Acta audiencia 12987-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-11-10',
+  },
+  {
+    id: 'a-201',
+    judgeId: 2,
+    nombre: 'Resolución libertad cautelar 33210-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-07-28',
+  },
+  {
+    id: 'a-301',
+    judgeId: 3,
+    nombre: 'Resolución excarcelación 78123-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2022-09-12',
+  },
+  {
+    id: 'a-302',
+    judgeId: 3,
+    nombre: 'Dictamen fiscal 90045-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2022-11-25',
+  },
+  {
+    id: 'a-401',
+    judgeId: 4,
+    nombre: 'Acta audiencia 43219-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-06-20',
+  },
+  {
+    id: 'a-501',
+    judgeId: 5,
+    nombre: 'Resolución excarcelación 31456-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2022-10-18',
+  },
+  {
+    id: 'a-601',
+    judgeId: 6,
+    nombre: 'Resolución excarcelación 22134-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2022-09-05',
+  },
+  {
+    id: 'a-602',
+    judgeId: 6,
+    nombre: 'Informe de incomparecencia 66543-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-01-08',
+  },
+  {
+    id: 'a-701',
+    judgeId: 7,
+    nombre: 'Acta audiencia 57831-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-02-24',
+  },
+  {
+    id: 'a-801',
+    judgeId: 8,
+    nombre: 'Resolución revocatoria 19023-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-04-20',
+  },
+  {
+    id: 'a-901',
+    judgeId: 9,
+    nombre: 'Acta de incomparecencia 72341-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-05-15',
+  },
+  {
+    id: 'a-1001',
+    judgeId: 10,
+    nombre: 'Resolución excarcelación 29087-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-06-25',
+  },
+  {
+    id: 'a-1101',
+    judgeId: 11,
+    nombre: 'Resolución excarcelación 84561-2022.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2022-07-28',
+  },
+  {
+    id: 'a-1102',
+    judgeId: 11,
+    nombre: 'Resolución revocatoria 19034-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-05-02',
+  },
+  {
+    id: 'a-1201',
+    judgeId: 12,
+    nombre: 'Acta de incomparecencia 91230-2023.pdf',
+    url: 'https://www.boletinoficial.gob.ar/',
+    fechaCarga: '2023-03-18',
   },
 ];
 
@@ -783,5 +1280,13 @@ export class JudgesService {
 
   getRawData(): Judge[] {
     return MOCK_JUDGES;
+  }
+
+  getCasosByJudge(judgeId: number): Caso[] {
+    return MOCK_CASOS.filter((c) => c.judgeId === judgeId);
+  }
+
+  getArchivosByJudge(judgeId: number): ArchivoPublico[] {
+    return MOCK_ARCHIVOS.filter((a) => a.judgeId === judgeId);
   }
 }


### PR DESCRIPTION
## Resumen

Este PR acompaña a [feat/judge-detail-enhancements](https://github.com/observatorio-justicia-argentina/observatorio-justicia-argentina-frontend/pull/3) en el frontend. Agrega los dos endpoints que la página de detalle de juez necesita, expande el modelo de datos del juez y agrega soporte de paginación.

## Cambios

### Nuevos endpoints

- `GET /api/judges/:id/casos?page=1&limit=10` → devuelve `PaginatedResult<Caso>` con paginación server-side
- `GET /api/judges/:id/archivos` → devuelve `ArchivoPublico[]`
- Ambos endpoints devuelven `404` si el juez no existe

### Modelo de juez expandido (`judges.interface.ts`)

Nuevos campos en `Judge`:
- `isDemoData` — bandera para indicar datos de demostración
- `jurisdiction` — `{ fuero, instance, scope, competence }`
- `workAddress`, `workHours`
- `salary` — `{ grossMonthlyARS, acordada, category, lastUpdated }`
- `appointmentDate`, `appointmentBody`, `yearsOnBench`
- `sourceLinks` — links a fuentes oficiales (Poder Judicial, registros públicos)
- `publicBio` (opcional)

Nuevos tipos: `Caso`, `ArchivoPublico`, `ResultadoCaso`, `PaginatedResult<T>`

### Mock data

- 3 jueces demo con datos completos en todos los nuevos campos
- Casos y archivos asociados a cada juez para testing end-to-end

<img width="1611" height="1007" alt="image" src="https://github.com/user-attachments/assets/72b46c64-f8fb-473d-a7fa-24cdcc3d1f5a" />


## Testing

```bash
# Casos paginados
GET /api/judges/1/casos?page=1&limit=10

# Segunda página
GET /api/judges/1/casos?page=2&limit=5

# Archivos
GET /api/judges/1/archivos

# 404
GET /api/judges/9999/casos

