### PR TITLE
fix: Remover atributos sin utilizar, mejorar y agregar reglas de tipado

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
 import { Response, Request } from 'express';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { Contact } from 'src/contacts/contacts.interface';
 
 const COOKIE_NAME = 'oja_token';
 const isProd = process.env.NODE_ENV === 'production';
@@ -29,7 +30,8 @@ export class AuthController {
   /** POST /api/auth/register */
   @Post('register')
   async register(
-    @Body() body: {
+    @Body()
+    body: {
       nombre?: string;
       email?: string;
       dni?: string;
@@ -69,7 +71,7 @@ export class AuthController {
   /** GET /api/auth/me — requiere JWT */
   @UseGuards(JwtAuthGuard)
   @Get('me')
-  me(@Req() req: Request & { user: any }) {
+  me(@Req() req: Request & { user: Contact }) {
     return req.user;
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, ConflictException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ContactsService } from '../contacts/contacts.service';
 import { ContactPublic } from '../contacts/contacts.interface';
@@ -35,6 +35,7 @@ export class AuthService {
     if (!contact) {
       throw new UnauthorizedException('Email o contraseña incorrectos');
     }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { passwordHash: _, ...user } = contact;
     return { user, token: this.sign(user), cookieMaxAge: COOKIE_MAX_AGE };
   }

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,11 +1,14 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { ContactPublic } from 'src/contacts/contacts.interface';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  handleRequest(err: any, user: any) {
+  handleRequest<Tuser = ContactPublic>(err: Error | null, user: Tuser | false): Tuser {
     if (err || !user) {
-      throw err ?? new UnauthorizedException('Sesión inválida o expirada. Iniciá sesión nuevamente.');
+      throw (
+        err ?? new UnauthorizedException('Sesión inválida o expirada. Iniciá sesión nuevamente.')
+      );
     }
     return user;
   }

--- a/src/contacts/contacts.service.ts
+++ b/src/contacts/contacts.service.ts
@@ -15,9 +15,7 @@ export class ContactsService {
     rol: string;
     password: string;
   }): Promise<ContactPublic> {
-    const existing = this.store.find(
-      (c) => c.email.toLowerCase() === data.email.toLowerCase(),
-    );
+    const existing = this.store.find((c) => c.email.toLowerCase() === data.email.toLowerCase());
     if (existing) {
       throw new ConflictException('Ya existe un contacto registrado con ese email');
     }
@@ -40,14 +38,13 @@ export class ContactsService {
     };
 
     this.store.push(contact);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { passwordHash: _, ...pub } = contact;
     return pub;
   }
 
   async validatePassword(email: string, password: string): Promise<Contact | null> {
-    const contact = this.store.find(
-      (c) => c.email.toLowerCase() === email.toLowerCase(),
-    );
+    const contact = this.store.find((c) => c.email.toLowerCase() === email.toLowerCase());
     if (!contact) return null;
     const ok = await bcrypt.compare(password, contact.passwordHash);
     return ok ? contact : null;
@@ -60,6 +57,7 @@ export class ContactsService {
   findById(id: string): ContactPublic | undefined {
     const c = this.store.find((c) => c.id === id);
     if (!c) return undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { passwordHash: _, ...pub } = c;
     return pub;
   }


### PR DESCRIPTION
## Descripción

Se corrigen errores de linter de forma manual, ya que `npm run lint:fix` no resolvió ninguno de los casos presentes.

Cambios principales:
- Ajustes de tipado (reemplazo/revisión de `any` en casos necesarios)
- Manejo de variables no utilizadas en desestructuración (uso de `_` cuando aplica)
- Correcciones puntuales para cumplir con las reglas de ESLint

No se introducen cambios funcionales.

## Tipo de cambio

- [ ] `feat` — nueva funcionalidad
- [x] `fix` — corrección de bug
- [x] `refactor` — refactor sin cambio de comportamiento
- [ ] `docs` — solo documentación
- [ ] `chore` — mantenimiento, dependencias
- [ ] `ci` — cambios en CI/CD
- [ ] Cambio que rompe compatibilidad (**BREAKING CHANGE**)

## Issue relacionado
Closes #4 

## ¿Cómo probarlo?

1.npm install
2.npm run lint

## Checklist obligatorio

- [x] El CI está en verde (lint + typecheck + build)
- [x] Los commits siguen el formato [Conventional Commits](https://conventionalcommits.org)
- [x] No hay `console.log` ni código de debug
- [x] No hay secrets ni tokens hardcodeados
- [x] No se exponen campos sensibles (passwordHash, etc.) en las respuestas HTTP
- [x] Si cambié endpoints o tipos, actualicé el README
- [x] Si agregué una dependencia, justifiqué por qué
- [x] El PR apunta a `develop`, no a `main`

## Notas para el revisor

Usé `// eslint-disable-next-line @typescript-eslint/no-unused-vars` en los casos puntuales donde los parámetros deben mantenerse por seguridad (No exponer el passwordhash en las requests).

Esto evita cambios innecesarios en la API o en la estructura existente, manteniendo compatibilidad sin afectar el comportamiento.

Además, se aplicaron las interfaces `Contact` y `ContactPublic` para mejorar el tipado en lugar de `any`. Estas asignaciones se hicieron en base al uso actual, pero pueden requerir una validación adicional para asegurar que reflejen correctamente todo el flujo de datos.